### PR TITLE
Update generate()'s typedef to match its real definition

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -48,7 +48,7 @@ declare module 'purpl-markov-chain' {
      * 
      * @param config - The config to use for the generation.
      */
-    generate(config: GenerationConfig): string
+    generate(config?: GenerationConfig): string
 
     /**
      * Get a JSON version of the chain object.


### PR DESCRIPTION
.generate()'s `config` argument is optional, but this file doesn't reflect that. This leads to a false alarm when working with TypeScript saying that this argument is required. By making the `config` argument optional, the false alarm goes away.